### PR TITLE
Don't use Mailersend by default in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,6 @@ Run the setup script:
 bin/setup
 ```
 
-### Configure Mailersend
-
-Three environment variables need to be set for Mailersend to work:
-
-- `HOST` (e.g. localhost:3000)
-- `MAILERSEND_SMTP_USERNAME`
-- `MAILERSEND_SMTP_PASSWORD`
-
-The username and password are too sensitive to store in the repo. Contact jeremy@haberman.dev for details.
-
 ## Running the app
 
 The app uses a Procfile. In a development environment this takes care of:
@@ -65,6 +55,22 @@ See the [Rails testing guide](https://guides.rubyonrails.org/testing.html) for d
 ### Branches, commits and merges
 
 Avoid committing directly to the `main` branch. Use branches and pull requests for getting commits into `main`.
+
+### Email
+
+Mailersend is used in production, but it is disabled in development. Emails sent in
+a local dev environment appear in the log.
+
+If you want to use Mailersend locally,
+
+1. Un-comment-out the section that configures Mailersend in config/environments/development.rb.
+2. Set three environment variables:
+
+- `HOST` (e.g. localhost:3000)
+- `MAILERSEND_SMTP_USERNAME`
+- `MAILERSEND_SMTP_PASSWORD`
+
+The username and password are too sensitive to store in the repo. Contact jeremy@haberman.dev for details.
 
 # Libraries
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,18 +43,18 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # ActionMailer
-  config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: ENV['HOST'] }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    :address   => 'smtp.mailersend.net',
-    :port      => 587,
-    :user_name => ENV['MAILERSEND_SMTP_USERNAME'],
-    :password  => ENV['MAILERSEND_SMTP_PASSWORD'],
-    :authentication => :login,
-    :starttls => true
-  }
+  # Un-comment-out this section to use Mailersend in your local dev environment
+  # config.action_mailer.raise_delivery_errors = true
+  # config.action_mailer.default_url_options = { host: ENV['HOST'] }
+  # config.action_mailer.delivery_method = :smtp
+  # config.action_mailer.smtp_settings = {
+  #   :address   => 'smtp.mailersend.net',
+  #   :port      => 587,
+  #   :user_name => ENV['MAILERSEND_SMTP_USERNAME'],
+  #   :password  => ENV['MAILERSEND_SMTP_PASSWORD'],
+  #   :authentication => :login,
+  #   :starttls => true
+  # }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
By default, let emails go nowhere but the log.