### PR TITLE
Add reCAPTCHA to registration form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ gem 'judoscale-rails'
 
 gem 'mailersend-ruby'
 
+gem 'recaptcha', '~> 5.17'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
@@ -93,5 +95,3 @@ group :test do
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'
 end
-
-gem "recaptcha", "~> 5.17"

--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,5 @@ group :test do
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'
 end
+
+gem "recaptcha", "~> 5.17"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
+    recaptcha (5.17.0)
     regexp_parser (2.9.0)
     reline (0.4.3)
       io-console (~> 0.5)
@@ -383,6 +384,7 @@ DEPENDENCIES
   rack-attack (~> 6.7)
   rails (~> 7.1.3, >= 7.1.3.2)
   rails-controller-testing
+  recaptcha (~> 5.17)
   rubocop (~> 1.62)
   rubocop-rails
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Requirements for the software and other tools to build, test and push:
 - [HERE](https://developer.here.com/) – geolocation
 - [Mailersend](https://www.mailersend.com/) - email
 - [Heroku](https://www.heroku.com/home) - hosting
+- [reCAPTCHA](https://www.google.com/recaptcha/about/) - bot protection
 
 ## Setup
 
@@ -32,10 +33,12 @@ Set an environment variable for the HERE API key. Create a file named **.env.dev
 and add a line for the key:
 
 ```env
-HERE_API_KEY="XXXXXXXXXX"
+HERE_API_KEY=XXXXXXXXXX
+RECAPTCHA_SITE_KEY=XXXXXXXXXX
+RECAPTCHA_SECRET_KEY=XXXXXXXXXX
 ```
 
-Contact jeremy@haberman.dev to get the value for the key.
+Contact jeremy@haberman.dev to get the value for the keys.
 
 ## Running the app
 
@@ -133,6 +136,7 @@ Most notable libraries and services used by the app:
 - [TailwindCSS](https://github.com/rails/tailwindcss-rails) - styling
 - [Mailersend](https://mailersend.com) – email
 - [HERE](https://developer.here.com/)
+- [recaptcha](https://github.com/ambethia/recaptcha)
 
 # Environments and Deployments
 
@@ -203,6 +207,8 @@ heroku config:set HOST=XXXXXXXX --remote staging
 heroku config:set MAILERSEND_SMTP_USERNAME=XXXXXXXX --remote staging
 heroku config:set MAILERSEND_SMTP_PASSWORD=XXXXXXXX --remote staging
 heroku config:set HERE_API_KEY=XXXXXXXX --remote staging
+heroku config:set RECAPTCHA_SITE_KEY=XXXXXXXX --remote staging
+heroku config:set RECAPTCHA_SECRET_KEY=XXXXXXXX --remote staging
 ```
 
 Enable PostgreSQL:
@@ -239,6 +245,8 @@ heroku config:set HOST=XXXXXXXX --remote production
 heroku config:set MAILERSEND_SMTP_USERNAME=XXXXXXXX --remote production
 heroku config:set MAILERSEND_SMTP_PASSWORD=XXXXXXXX --remote production
 heroku config:set HERE_API_KEY=XXXXXXXX --remote production
+heroku config:set RECAPTCHA_SITE_KEY=XXXXXXXX --remote production
+heroku config:set RECAPTCHA_SECRET_KEY=XXXXXXXX --remote production
 ```
 
 Enable PostgreSQL:

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,6 +5,8 @@ module Users
     before_action :configure_sign_up_params, only: [:create] # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :configure_account_update_params, only: [:update]
 
+    prepend_before_action :check_captcha, only: [:create] # rubocop:disable Rails/LexicallyScopedActionFilter
+
     def edit
       if params['welcome']
         render :welcome
@@ -46,6 +48,17 @@ module Users
 
     def after_inactive_sign_up_path_for(resource) # rubocop:disable Lint/UnusedMethodArgument
       new_user_session_path
+    end
+
+    private
+
+    def check_captcha
+      return if verify_recaptcha
+
+      self.resource = resource_class.new user_params
+      resource.validate
+
+      redirect_to new_user_registration_path, alert: 'reCAPTCHA verification failed'
     end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -58,7 +58,8 @@ module Users
       self.resource = resource_class.new user_params
       resource.validate
 
-      redirect_to new_user_registration_path, alert: 'reCAPTCHA verification failed'
+      flash[:alert] = I18n.t('recaptcha_verification_failed')
+      render :new, status: :unprocessable_entity
     end
   end
 end

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -63,6 +63,11 @@
         </div>
       </fieldset>
 
+      <div class="mt-6 w-full flex justify-center">
+        <!-- If the reCAPTCHA fails, the page is re-rendered. 'noscript: false' makes sure the reCAPTCHA is reloaded. -->
+        <%= recaptcha_tags noscript: false %>
+      </div>
+
       <div class="mt-6">
         <button type="submit" class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Sign up</button>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,4 @@ en:
   profile_updated: 'Profile updated'
   options_updated: 'Options updated'
   profile_updated_pending_reconfirmation: 'Profile updated. Please check your email to confirm the changes.'
+  recaptcha_verification_failed: 'reCAPTCHA verification failed'


### PR DESCRIPTION
Last week, we started getting a bunch of registration attempts from email addresses that looked suspicious and weren't confirmed.

This adds [reCAPTCHA](https://www.google.com/recaptcha/about/) to the registration form.

I chose v2 (instead of v3) because it's simpler and easier to implement.

I set up the reCAPTCHA sites in a new Google Cloud Platform project using the communitylocator@simplyalwaysawake.com user. There are separate keys for dev and staging/prod.

<img src="https://github.com/simplyalwaysawake/community-locator/assets/163210/ea5a2265-c0c9-49e9-9c3f-2da82ff7054f" width=300 />
